### PR TITLE
Update the README in github to point to the website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 README
 ======
 
+This is the source code of the web page of the BigScience Workshop:
+![https://bigscience.huggingface.co/](https://bigscience.huggingface.co/)
+
+If you are part of the BigScience project,
+you may propose modifications to the web page by submitting a pull request here.
+
 First things first
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ README
 ======
 
 This is the source code of the web page of the BigScience Workshop:
-![https://bigscience.huggingface.co/](https://bigscience.huggingface.co/)
+[https://bigscience.huggingface.co/](https://bigscience.huggingface.co/)
 
 If you are part of the BigScience project,
 you may propose modifications to the web page by submitting a pull request here.


### PR DESCRIPTION
Small update at the top of the README in github:
the problem was that the README was just a copy of the mdwiki template README, and there was no link to the actual website of the Workshop.
This pull request just fixes this.
